### PR TITLE
feature/default-response-headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ With server-sent events, it's possible for a server to send new data to a web pa
 By creating a new instance of `ServerSentEvents` class you will get access to methods required to stream data to the client.
 
 Simple return `ServerSentEvents.stream.readable` in a `Response` instance to start streaming data.\
+⚠️ Do not forget to return the proper response headers.\
 ⚠️ The streaming Response implementation depends on your back-end application.
 
 ```typescript
@@ -41,7 +42,7 @@ import ServerSentEvents from '@alessiofrittoli/server-sent-events'
 const sse = new ServerSentEvents()
 
 return (
-	new Response( sse.stream.readable )
+	new Response( sse.stream.readable, { headers: sse.headers } )
 )
 ```
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -54,6 +54,8 @@ class ServerSentEvents implements ServerSentEventsProps
 	/** Flag whether {@link WritableStreamDefaultWriter} has been closed or not. */
 	closed: boolean
 	retry
+	/** Default headers sent to the client. */
+	headers: Headers
 
 
 	constructor( props?: ServerSentEventsProps )
@@ -63,6 +65,13 @@ class ServerSentEvents implements ServerSentEventsProps
 		this.encoder	= new TextEncoder()
 		this.closed		= false
 		this.retry		= props?.retry
+		this.headers	= new Headers( {
+			'Content-Type'		: 'text/event-stream',
+			'Connection'		: 'keep-alive',
+			'Cache-Control'		: 'no-cache, no-transform',
+			'X-Accel-Buffering'	: 'no',
+			'Content-Encoding'	: 'none',
+		} )
 
 		if ( this.retry ) {
 			this.write( this.formatRetry( this.retry ) )


### PR DESCRIPTION
Adds a new property `headers` which is an instance of [Headers](https://developer.mozilla.org/en-US/docs/Web/API/Headers) to the `ServerSentEvents` class.

List of added default Response Headers:
- Content-Type: text/event-stream
- Connection : keep-alive
- Cache-Control: no-cache, no-transform
- X-Accel-Buffering: no
- Content-Encoding: none